### PR TITLE
Add OpenRouter fallback route

### DIFF
--- a/server.js
+++ b/server.js
@@ -3251,7 +3251,7 @@ app.post("/generate_openai", jsonParser, function (request, response_generate_op
         api_key_openai = readSecret(SECRET_KEYS.OPENROUTER);
         // OpenRouter needs to pass the referer: https://openrouter.ai/docs
         headers = { 'HTTP-Referer': request.headers.referer };
-        bodyParams = { 'transforms': ["middle-out"] };
+        bodyParams = { 'transforms': ["middle-out"], 'route': "fallback" };
     }
 
     if (!api_key_openai && !request.body.reverse_proxy) {


### PR DESCRIPTION
No-op right now - just prepares to let requests fall back to open source models

Todo for a followup: allow users to change "fallback" to "direct" in the UI, or specify their own routing config via https://github.com/OpenRouterTeam/schemas